### PR TITLE
'*.go': ditch import path checks.

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 import (
 	"go.opentelemetry.io/otel"

--- a/example/config/config.go
+++ b/example/config/config.go
@@ -28,7 +28,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config // import "github.com/containerd/otelttrpc/example/config"
+package config
 
 import (
 	"go.opentelemetry.io/otel"

--- a/interceptor.go
+++ b/interceptor.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 import (
 	"context"

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package internal // import "github.com/containerd/ttrpc/otelttrpc"
+package internal
 
 import (
 	"strings"

--- a/metadata_supplier.go
+++ b/metadata_supplier.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 import (
 	"context"

--- a/semconv.go
+++ b/semconv.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 import (
 	"go.opentelemetry.io/otel/attribute"

--- a/version.go
+++ b/version.go
@@ -30,7 +30,7 @@
    limitations under the License.
 */
 
-package otelttrpc // import "github.com/containerd/otelttrpc"
+package otelttrpc
 
 // Version is the current release version of the ttRPC instrumentation.
 func Version() string {


### PR DESCRIPTION
Remove golang 'custom import path check' comments. It's a pure accident (of the monkey see monkey do type) that we have them. They reportedly break RPM package building for some otelttrpc downstream consumers.